### PR TITLE
Add react-native CLI dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "jest": "^29.2.1",
     "metro-react-native-babel-preset": "0.76.8",
     "react-test-renderer": "18.2.0",
-    "typescript": "4.8.4"
+    "typescript": "4.8.4",
+    "@react-native-community/cli": "latest"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
## Summary
- add `@react-native-community/cli` to devDependencies as required by react-native

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842dca44048832da7c78dd4a1e10023